### PR TITLE
docs: mark project as discontiuned

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+# ⚠️ PROJECT DISCONTINUED / PROJEKT EINGESTELLT
+
+**Development stopped on February 11, 2026**
+
+This project has been discontinued. There are already 20+ similar apps on the market that implement the same concept (AI-powered calorie tracking with meal scanning). The lack of unique differentiation led to the decision to stop development at this stage.
+
+The codebase remains available for educational purposes and as a reference implementation for:
+- React Native (Expo) + TypeScript
+- Supabase integration
+- NativeWind (Tailwind for RN)
+- Feature-first architecture
+
+---
+
+**Entwicklung eingestellt am 11. Februar 2026**
+
+Dieses Projekt wurde eingestellt. Es existieren bereits 20+ ähnliche Apps auf dem Markt, die dasselbe Konzept (KI-gestütztes Kalorienzählen mit Meal-Scan) umsetzen. Die fehlende Alleinstellung führte zur Entscheidung, die Entwicklung an diesem Punkt zu beenden.
+
+Der Code bleibt verfügbar für Bildungszwecke und als Referenz-Implementierung.
+
+---
+
 # MenuMate
 
 Eine intelligente Kalorien-Tracking-App für iOS und Android. Mahlzeiten fotografieren, Nährwerte tracken, Fortschritt überwachen.


### PR DESCRIPTION
This pull request updates the `README.md` to announce that the project has been discontinued as of February 11, 2026. The notice explains the reasons for stopping development and clarifies that the codebase is now available for educational and reference purposes. The announcement is provided in both English and German.

Project status update:

* Added a prominent notice at the top of `README.md` stating the discontinuation of the project, including the date development stopped and the reasoning behind the decision.
* Clarified that the codebase remains available for educational use and as a reference for technologies such as React Native (Expo), TypeScript, Supabase, NativeWind, and feature-first architecture.
* Provided the discontinuation announcement in both English and German for broader accessibility.